### PR TITLE
add simple configuration get

### DIFF
--- a/Main/Main/Controllers/ConfigurationController.cs
+++ b/Main/Main/Controllers/ConfigurationController.cs
@@ -1,0 +1,25 @@
+using Main.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Main.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{v:apiVersion}/configuration")]
+public class ConfigurationController
+{
+    private readonly IConfigurationService _configurationService;
+
+    public ConfigurationController(IConfigurationService configurationService)
+    {
+        _configurationService = configurationService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var result = await _configurationService.Configuration();
+
+        return new OkObjectResult(result);
+    }
+}

--- a/Main/Main/Program.cs
+++ b/Main/Main/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddTransient<IStateStoreService, StateStoreService>();
 builder.Services.AddTransient<ISecretStoreService, SecretStoreService>();
 builder.Services.AddTransient<IServiceInvocationService, ServiceInvocationService>();
 builder.Services.AddTransient<IBlobStorageService, BlobStorageService>();
+builder.Services.AddTransient<IConfigurationService, ConfigurationService>();
 
 builder.Services.AddActors(options =>
 {

--- a/Main/Main/Services/ConfigurationService.cs
+++ b/Main/Main/Services/ConfigurationService.cs
@@ -1,0 +1,19 @@
+using Dapr.Client;
+
+namespace Main.Services;
+
+public class ConfigurationService : IConfigurationService
+{
+    private readonly DaprClient _daprClient;
+
+    public ConfigurationService(DaprClient daprClient)
+    {
+        _daprClient = daprClient;
+    }
+    
+    public async Task<GetConfigurationResponse> Configuration()
+    {
+        var result = await _daprClient.GetConfiguration("configuration", new[] {"orderId1", "orderId2"});
+        return result;
+    }
+}

--- a/Main/Main/Services/IConfigurationService.cs
+++ b/Main/Main/Services/IConfigurationService.cs
@@ -1,0 +1,8 @@
+using Dapr.Client;
+
+namespace Main.Services;
+
+public interface IConfigurationService
+{
+    Task<GetConfigurationResponse> Configuration();
+}

--- a/Main/Main/components/configuration.yaml
+++ b/Main/Main/components/configuration.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: configuration
+spec:
+  type: configuration.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""

--- a/Main/requests/configuration.http
+++ b/Main/requests/configuration.http
@@ -1,0 +1,3 @@
+### GET Configuration
+GET http://localhost:5070/api/v1.0/configuration
+Content-Type: application/json


### PR DESCRIPTION
adds a simple configuration get request as described here:
https://docs.dapr.io/developing-applications/building-blocks/configuration/howto-manage-configuration/

Configuration API is currently in preview and probably needs to be adjusted in future releases 