### PR TITLE
add servicebus queue binding as input binding example

### DIFF
--- a/Main/Main/Models/ServiceBusMessageDto.cs
+++ b/Main/Main/Models/ServiceBusMessageDto.cs
@@ -1,0 +1,3 @@
+namespace Main.Models;
+
+public record ServiceBusMessageDto(string Message);

--- a/Main/Main/Program.cs
+++ b/Main/Main/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddTransient<IStateStoreService, StateStoreService>();
 builder.Services.AddTransient<ISecretStoreService, SecretStoreService>();
 builder.Services.AddTransient<IServiceInvocationService, ServiceInvocationService>();
 builder.Services.AddTransient<IBlobStorageService, BlobStorageService>();
+builder.Services.AddTransient<IServiceBusQueueService, ServiceBusQueueService>();
 builder.Services.AddTransient<IConfigurationService, ConfigurationService>();
 
 builder.Services.AddActors(options =>

--- a/Main/Main/Services/IServiceBusQueueService.cs
+++ b/Main/Main/Services/IServiceBusQueueService.cs
@@ -1,0 +1,8 @@
+using Main.Models;
+
+namespace Main.Services;
+
+public interface IServiceBusQueueService
+{
+    Task AddMessage(ServiceBusMessageDto message);
+}

--- a/Main/Main/Services/ServiceBusQueueService.cs
+++ b/Main/Main/Services/ServiceBusQueueService.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Dapr.Client;
+using Main.Models;
+
+namespace Main.Services;
+
+public class ServiceBusQueueService : IServiceBusQueueService
+{
+    private readonly DaprClient _daprClient;
+
+    public ServiceBusQueueService(DaprClient daprClient)
+    {
+        _daprClient = daprClient;
+    }
+    
+    public async Task AddMessage(ServiceBusMessageDto message)
+    {
+        var bindingRequest = new BindingRequest("servicebusqueue", "create")
+        {
+            Data = JsonSerializer.SerializeToUtf8Bytes(message),
+        };
+
+        await _daprClient.InvokeBindingAsync(bindingRequest);
+    }
+}

--- a/Main/Main/components/servicebusqueue.yaml
+++ b/Main/Main/components/servicebusqueue.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: servicebusqueue
+spec:
+  type: bindings.azure.servicebusqueues
+  version: v1
+  metadata:
+    - name: connectionString
+      value: [servicebus queue connection string]
+    - name: queueName
+      value: example-queue

--- a/Main/requests/binding.http
+++ b/Main/requests/binding.http
@@ -1,5 +1,5 @@
 ### POST create blob application
-POST http://localhost:5070/api/v1.0/binding
+POST http://localhost:5070/api/v1.0/binding/blob
 Content-Type: application/json
 
 {
@@ -68,4 +68,23 @@ Content-Type: application/json
     "blobName": "test-dapr-api.txt"
   },
   "operation": "delete"
+}
+
+### POST send service bus message application
+POST http://localhost:5070/api/v1.0/binding/send-message
+Content-Type: application/json
+
+{
+ "message": "servicebus queue test message"
+}
+
+### POST send service bus message dapr binding
+POST http://localhost:3570/v1.0/bindings/servicebusqueue
+Content-Type: application/json
+
+{
+  "data": {
+    "message": "service bus queue test message dapr api"
+  },
+  "operation": "create"
 }


### PR DESCRIPTION
adds the servicebus queue binding as example for the input binding.

https://docs.dapr.io/developing-applications/building-blocks/bindings/bindings-overview/
https://docs.dapr.io/reference/components-reference/supported-bindings/servicebusqueues/