### PR TITLE
update to dapr dotnet sdk 1.8.0

### DIFF
--- a/Main/Main/Main.csproj
+++ b/Main/Main/Main.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.7.0" />
-      <PackageReference Include="Dapr.AspNetCore" Version="1.7.0" />
-      <PackageReference Include="Dapr.Extensions.Configuration" Version="1.7.0" />
+      <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.8.0" />
+      <PackageReference Include="Dapr.AspNetCore" Version="1.8.0" />
+      <PackageReference Include="Dapr.Extensions.Configuration" Version="1.8.0" />
       <PackageReference Include="Man.Dapr.Sidekick.AspNetCore" Version="1.2.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
       <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />

--- a/Main/Main/configuration.yaml
+++ b/Main/Main/configuration.yaml
@@ -8,6 +8,3 @@ spec:
     samplingRate: "1"
     zipkin:
       endpointAddress: "http://localhost:9411/api/v2/spans"
-  features:
-    - name: PubSub.Routing
-      enabled: true

--- a/Second/Second/Second.csproj
+++ b/Second/Second/Second.csproj
@@ -7,9 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.7.0" />
-      <PackageReference Include="Dapr.AspNetCore" Version="1.7.0" />
-      <PackageReference Include="Dapr.AzureFunctions.Extension" Version="0.10.0-preview01" />
+      <PackageReference Include="Dapr.Actors.AspNetCore" Version="1.8.0" />
+      <PackageReference Include="Dapr.AspNetCore" Version="1.8.0" />
       <PackageReference Include="Man.Dapr.Sidekick.AspNetCore" Version="1.2.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     </ItemGroup>


### PR DESCRIPTION
update to dotnet sdk 1.8.0
removes the PubSub.Routing from preview features